### PR TITLE
Refactor: Improve type inference for EnumStore

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,9 +5,6 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="MainActivity">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreType.kt
+++ b/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreType.kt
@@ -15,7 +15,27 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 sealed class EnumStoreType<T : Any>(
     var defaultValue: T
 ) {
+    private var editValue: T? = null
+
     abstract fun getKey(keyName: String): Preferences.Key<T>
+
+    @Suppress("UNCHECKED_CAST")
+    companion object {
+        inline fun <reified R: Any> R.getTypeFromValue(): EnumStoreType<R> {
+            return when (R::class) {
+                String::class -> TypeString
+                Boolean::class -> TypeBoolean
+                Set::class -> TypeStringSet
+                Int::class -> TypeInt
+                Double::class -> TypeDouble
+                Long::class -> TypeLong
+                ByteArray::class -> TypeByteArray
+                Float::class -> TypeFloat
+
+                else -> error("Type ${R::class} is not supported")
+            } as EnumStoreType<R>
+        }
+    }
 
     data object TypeString : EnumStoreType<String>("") {
         override fun getKey(keyName: String): Preferences.Key<String> =


### PR DESCRIPTION
This commit refactors the `EnumStoreType` and `EnumStoreExtension` to improve type inference when getting and setting values.

Previously, the preference key had to be explicitly provided. Now, the type can be inferred from the default value or the value being set.

This change makes the API more concise and easier to use.

Specifically, the following changes were made:

- Added a companion object to `EnumStoreType` with a `getTypeFromValue` function to infer the `EnumStoreType` from a given value.
- Modified the `get` and `set` extension functions in `EnumStoreExtension` to utilize the new `getTypeFromValue` function, removing the need to explicitly pass the `Preferences.Key`.
- Removed the standalone `getPreferenceKey` function from `EnumStoreExtension` as it's now handled within `EnumStoreType`.