### PR TITLE
shared-enum-datastore

### DIFF
--- a/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStore.kt
+++ b/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStore.kt
@@ -35,9 +35,8 @@ class EnumStore(context: Context) : BaseDatastore() {
     fun <T> from(markedEnum: T): EnumStoreImplInternal where T: Enum<*>, T : EnumStoreMarker {
         val name = when (markedEnum) {
             is EnumStoreShared -> {
-                markedEnum::class.annotations.filterIsInstance<PartOf>().firstOrNull()?.let {
-                    it.collection.simpleName
-                } ?: markedEnum::class.simpleName
+                markedEnum::class.java.annotations.filterIsInstance<PartOf>().firstOrNull()?.collection?.simpleName
+                    ?: markedEnum::class.simpleName
             }
             // markedEnum.getSharedTarget()?.simpleName ?: markedEnum::class.simpleName
             else -> markedEnum::class.simpleName

--- a/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreCollection.kt
+++ b/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreCollection.kt
@@ -4,7 +4,10 @@ import kotlin.reflect.KClass
 
 interface EnumStoreMarker
 
-interface EnumStoreCollection
+interface EnumStoreCollection: EnumStoreMarker
 
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
 annotation class PartOf(val collection: KClass<out EnumStoreCollection>)
-interface EnumStoreShared: EnumStoreCollection
+
+interface EnumStoreShared: EnumStoreMarker

--- a/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreCollection.kt
+++ b/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreCollection.kt
@@ -1,0 +1,10 @@
+package id.mohekkus.enumstore
+
+import kotlin.reflect.KClass
+
+interface EnumStoreMarker
+
+interface EnumStoreCollection
+
+annotation class PartOf(val collection: KClass<out EnumStoreCollection>)
+interface EnumStoreShared: EnumStoreCollection

--- a/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreOption.kt
+++ b/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreOption.kt
@@ -1,3 +1,0 @@
-package id.mohekkus.enumstore
-
-interface EnumStoreOption

--- a/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreType.kt
+++ b/EnumStore/src/main/java/id/mohekkus/enumstore/EnumStoreType.kt
@@ -19,6 +19,24 @@ sealed class EnumStoreType<T : Any>(
 
     abstract fun getKey(keyName: String): Preferences.Key<T>
 
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        inline fun <reified R: Any> R.getTypeFromValue(): EnumStoreType<R> {
+            return when (this::class) {
+                String::class -> TypeString
+                Boolean::class -> TypeBoolean
+                Set::class -> TypeStringSet
+                Int::class -> TypeInt
+                Double::class -> TypeDouble
+                Long::class -> TypeLong
+                ByteArray::class -> TypeByteArray
+                Float::class -> TypeFloat
+
+                else -> error("Type ${R::class} is not supported")
+            } as EnumStoreType<R>
+        }
+    }
+
     data object TypeString : EnumStoreType<String>("") {
         override fun getKey(keyName: String): Preferences.Key<String> =
             stringPreferencesKey(keyName)

--- a/app/src/main/java/id/mohekkus/example/storage/Variable.kt
+++ b/app/src/main/java/id/mohekkus/example/storage/Variable.kt
@@ -1,7 +1,14 @@
 package id.mohekkus.example.storage
 
-import id.mohekkus.enumstore.EnumStoreOption
+import id.mohekkus.enumstore.EnumStoreCollection
+import id.mohekkus.enumstore.EnumStoreShared
+import id.mohekkus.enumstore.PartOf
 
-enum class Variable: EnumStoreOption {
+enum class Variable: EnumStoreCollection {
     GREETING
+}
+
+@PartOf(Variable::class)
+enum class SubVariable: EnumStoreShared {
+    SUBGREETING
 }


### PR DESCRIPTION
adding option for modularize enum class while using same datastore file, utilizing annotation to make things easier 